### PR TITLE
Expand ~ in infer-dirs-from before dedup

### DIFF
--- a/truename-cache.el
+++ b/truename-cache.el
@@ -589,7 +589,7 @@ Otherwise, they are quietly skipped."
                                    infer-dirs-from))
                   (dolist (name sublist)
                     (when (file-name-absolute-p name)
-                      (puthash (file-name-directory name)
+                      (puthash (file-name-directory (expand-file-name name))
                                t
                                truename-cache--dedupped-dirs)))))
               (cl-loop


### PR DESCRIPTION
`infer-dirs-from` paths aren't expanded before being hashed, so `~/x` and `/home/me/x` are treated as different directories.
```el
(progn
  (truename-cache-collect-files-and-attributes
   :infer-dirs-from (list (list "~/x" (expand-file-name "~/x"))))
  (hash-table-keys truename-cache--dedupped-dirs))
;; => ("~/" "/home/me/")
```
This fixes meedstrom/org-node#177